### PR TITLE
add seconds support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to **NCronJob** will be documented in this file. The project
 
 ### Added
 
--   Ability to set the cron expressions can specify with second-level precision
+-   Ability to set cron expressions with second-level precision
 
 ## [0.10.0] - 2024-03-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to **NCronJob** will be documented in this file. The project
 
 ## [Unreleased]
 
+### Added
+
+-   Ability to set the cron expressions can specify with second-level precision
+
 ## [0.10.0] - 2024-03-18
 
 ### Added

--- a/src/LinkDotNet.NCronJob/NCronJobExtensions.cs
+++ b/src/LinkDotNet.NCronJob/NCronJobExtensions.cs
@@ -46,7 +46,8 @@ public static class NCronJobExtensions
 
         if (!string.IsNullOrEmpty(option.CronExpression))
         {
-            var cron = CrontabSchedule.TryParse(option.CronExpression)
+            var cronParseOptions = new CrontabSchedule.ParseOptions { IncludingSeconds = true };
+            var cron = CrontabSchedule.TryParse(option.CronExpression, cronParseOptions)
                        ?? throw new InvalidOperationException("Invalid cron expression");
             var entry = new CronRegistryEntry(typeof(T), new(option.Parameter), cron);
             services.AddSingleton(entry);

--- a/src/LinkDotNet.NCronJob/NCronJobExtensions.cs
+++ b/src/LinkDotNet.NCronJob/NCronJobExtensions.cs
@@ -46,9 +46,18 @@ public static class NCronJobExtensions
 
         if (!string.IsNullOrEmpty(option.CronExpression))
         {
-            var cronParseOptions = new CrontabSchedule.ParseOptions { IncludingSeconds = true };
+            using var serviceProvider = services.BuildServiceProvider();
+
+            var nCronJobOptions = serviceProvider.GetRequiredService<NCronJobOptions>();
+            
+            var cronParseOptions = new CrontabSchedule.ParseOptions 
+            { 
+                IncludingSeconds = nCronJobOptions.EnableSecondPrecision
+            };
+
             var cron = CrontabSchedule.TryParse(option.CronExpression, cronParseOptions)
                        ?? throw new InvalidOperationException("Invalid cron expression");
+
             var entry = new CronRegistryEntry(typeof(T), new(option.Parameter), cron);
             services.AddSingleton(entry);
         }

--- a/src/LinkDotNet.NCronJob/NCronJobOptions.cs
+++ b/src/LinkDotNet.NCronJob/NCronJobOptions.cs
@@ -12,4 +12,15 @@ public sealed class NCronJobOptions
     /// The higher the value, the longer it will take to run instant jobs.
     /// </remarks>
     public TimeSpan TimerInterval { get; set; } = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Determines whether cron expressions can specify second-level precision.
+    /// </summary>
+    /// <remarks>
+    /// When enabled, cron expressions must include a seconds field, allowing for more precise scheduling. 
+    /// By default, this is disabled, and cron expressions are expected to start with the minute field. 
+    /// Enabling this affects scheduling granularity and may influence performance, especially for jobs 
+    /// that are scheduled to run very frequently.
+    /// </remarks>
+    public bool EnableSecondPrecision { get; set; }
 }

--- a/tests/NCronJob.Tests/ExtensionsTests.cs
+++ b/tests/NCronJob.Tests/ExtensionsTests.cs
@@ -16,6 +16,18 @@ public class NCronJobTests
         act.ShouldThrow<InvalidOperationException>();
     }
 
+     [Fact]
+    public void AddingCronJobWithSecondPrecisionExpressionNotThrowException()
+    {
+        var everySecond = "* * * * * *";
+        var collection = new ServiceCollection();
+        collection.AddNCronJob(options => options.EnableSecondPrecision  = true);
+
+        Action act = () => collection.AddCronJob<FakeJob>(o => o.CronExpression = everySecond);
+
+        act.ShouldNotThrow();
+    }
+
     private sealed class FakeJob : IJob
     {
         public Task Run(JobExecutionContext context, CancellationToken token = default)


### PR DESCRIPTION
I've added cronjob expression support for seconds.

With current version I get this error:
![image](https://github.com/linkdotnet/NCronJob/assets/5130160/06033634-981e-4b37-9a3b-2e802a389245)
