### PR TITLE
refactor: Remove polling and wait for first task to finish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to **NCronJob** will be documented in this file. The project
 
 ## [Unreleased]
 
+### Fixed
+
+- Retry/Concurrency Attributes where ignored
+
 ## [2.4.5] - 2024-05-20
 
 ### Fixed

--- a/src/LinkDotNet.NCronJob/Configuration/NCronJobOptionBuilder.cs
+++ b/src/LinkDotNet.NCronJob/Configuration/NCronJobOptionBuilder.cs
@@ -1,7 +1,6 @@
 using Cronos;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using System;
 using System.Reflection;
 using System.Text;
 
@@ -51,10 +50,12 @@ public class NCronJobOptionBuilder
                                                 $"the global limit ({Settings.MaxDegreeOfParallelism}).");
         }
 
+        var attributes = new JobExecutionAttributes(typeof(T), null);
+
         foreach (var option in jobOptions.Where(c => !string.IsNullOrEmpty(c.CronExpression)))
         {
             var cron = GetCronExpression(option);
-            var entry = new JobDefinition(typeof(T), option.Parameter, cron, option.TimeZoneInfo);
+            var entry = new JobDefinition(typeof(T), option.Parameter, cron, option.TimeZoneInfo, JobPolicyMetadata: attributes);
             Services.AddSingleton(entry);
         }
 

--- a/src/LinkDotNet.NCronJob/RetryPolicies/RetryHandler.cs
+++ b/src/LinkDotNet.NCronJob/RetryPolicies/RetryHandler.cs
@@ -1,7 +1,5 @@
-using System.Reflection;
 using Polly;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 
 namespace LinkDotNet.NCronJob;
 

--- a/src/LinkDotNet.NCronJob/Scheduler/QueueWorker.cs
+++ b/src/LinkDotNet.NCronJob/Scheduler/QueueWorker.cs
@@ -24,14 +24,14 @@ internal sealed partial class QueueWorker : BackgroundService
         JobQueue jobQueue,
         TimeProvider timeProvider,
         ConcurrencySettings concurrencySettings,
-        ILoggerFactory loggerFactory,
+        ILogger<QueueWorker> logger,
         IHostApplicationLifetime lifetime)
     {
         this.jobExecutor = jobExecutor;
         this.registry = registry;
         this.jobQueue = jobQueue;
         this.timeProvider = timeProvider;
-        logger = loggerFactory.CreateLogger<QueueWorker>();
+        this.logger = logger;
         globalConcurrencyLimit = concurrencySettings.MaxDegreeOfParallelism;
         semaphore = new SemaphoreSlim(concurrencySettings.MaxDegreeOfParallelism);
 

--- a/tests/NCronJob.Tests/NCronJobRetryTests.cs
+++ b/tests/NCronJob.Tests/NCronJobRetryTests.cs
@@ -62,7 +62,7 @@ public sealed class NCronJobRetryTests : JobIntegrationBase
         fakeTimer.Advance(TimeSpan.FromMinutes(1));
 
         // 1 initial + 2 retries, all 3 failed; 20 seconds timeout because retries take time
-        var jobFinished = await WaitForJobsOrTimeout(3, 20);
+        var jobFinished = await WaitForJobsOrTimeout(3, TimeSpan.FromSeconds(20));
         jobFinished.ShouldBeTrue();
 
         FailingJobRetryTwice.Success.ShouldBeFalse();

--- a/tests/NCronJob.Tests/TestHelper.cs
+++ b/tests/NCronJob.Tests/TestHelper.cs
@@ -50,9 +50,9 @@ public abstract class JobIntegrationBase : IDisposable
 
     protected ServiceProvider CreateServiceProvider() => serviceProvider ??= ServiceCollection.BuildServiceProvider();
 
-    protected async Task<bool> WaitForJobsOrTimeout(int jobRuns, int timeOut = 200000)
+    protected async Task<bool> WaitForJobsOrTimeout(int jobRuns, TimeSpan? timeOut = null)
     {
-        using var timeoutTcs = new CancellationTokenSource(TimeSpan.FromSeconds(timeOut));
+        using var timeoutTcs = new CancellationTokenSource(timeOut ?? TimeSpan.FromSeconds(5));
         try
         {
             await Task.WhenAll(GetCompletionJobs(jobRuns, timeoutTcs.Token));


### PR DESCRIPTION
That should be a more stable way than `Task.Delay(1);`

I just started a bunch of `PrintHelloWorld` jobs as test - maybe you have a better testbed @falvarez1 