### PR TITLE
fix: Throw exception when missing instant job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to **NCronJob** will be documented in this file. The project
 
 - Instant jobs are executed with the highest priority.
 
+### Fixed
+
+- If an instant job is executed that is not registered, it will throw an exception instead of silently ignoring it.
+
 ## [2.4.6] - 2024-05-21
 
 ### Fixed

--- a/src/LinkDotNet.NCronJob/Configuration/JobOptionBuilder.cs
+++ b/src/LinkDotNet.NCronJob/Configuration/JobOptionBuilder.cs
@@ -55,5 +55,5 @@ public sealed class JobOptionBuilder
         return precisionRequired;
     }
 
-    internal List<JobOption> GetJobOptions() => jobOptions;
+    internal List<JobOption> GetJobOptions() => jobOptions.Count > 0 ? jobOptions : [new JobOption()];
 }

--- a/src/LinkDotNet.NCronJob/Configuration/NCronJobOptionBuilder.cs
+++ b/src/LinkDotNet.NCronJob/Configuration/NCronJobOptionBuilder.cs
@@ -42,7 +42,6 @@ public class NCronJobOptionBuilder
         var builder = new JobOptionBuilder();
         options?.Invoke(builder);
         var jobOptions = builder.GetJobOptions();
-
         var concurrencyAttribute = typeof(T).GetCustomAttribute<SupportsConcurrencyAttribute>();
         if (concurrencyAttribute != null && concurrencyAttribute.MaxDegreeOfParallelism > Settings.MaxDegreeOfParallelism)
         {
@@ -53,9 +52,11 @@ public class NCronJobOptionBuilder
 
         var attributes = new JobExecutionAttributes(typeof(T), null);
 
-        foreach (var option in jobOptions.Where(c => !string.IsNullOrEmpty(c.CronExpression)))
+        foreach (var option in jobOptions)
         {
-            var cron = GetCronExpression(option);
+            var cron = option.CronExpression is not null
+                ? GetCronExpression(option)
+                : null;
             var entry = new JobDefinition(typeof(T), option.Parameter, cron, option.TimeZoneInfo, JobPolicyMetadata: attributes);
             Services.AddSingleton(entry);
         }

--- a/src/LinkDotNet.NCronJob/Registry/JobDefinition.cs
+++ b/src/LinkDotNet.NCronJob/Registry/JobDefinition.cs
@@ -20,12 +20,14 @@ internal sealed record JobDefinition(
     /// <summary>
     /// The JobFullName is used as a unique identifier for the job type including anonymous jobs. This helps with concurrency management.
     /// </summary>
-    public string JobFullName => JobName == Type.Name ? Type.FullName ?? JobName : $"{typeof(DynamicJobFactory).Namespace}.{JobName}";
+    public string JobFullName => JobName == Type.Name
+        ? Type.FullName ?? JobName
+        : $"{typeof(DynamicJobFactory).Namespace}.{JobName}";
 
     public int JobExecutionCount => Interlocked.CompareExchange(ref jobExecutionCount, 0, 0);
 
     public void IncrementJobExecutionCount() => Interlocked.Increment(ref jobExecutionCount);
-    
+
     public RetryPolicyAttribute? RetryPolicy => JobPolicyMetadata?.RetryPolicy;
     public SupportsConcurrencyAttribute? ConcurrencyPolicy => JobPolicyMetadata?.ConcurrencyPolicy;
 }

--- a/src/LinkDotNet.NCronJob/Registry/JobRegistry.cs
+++ b/src/LinkDotNet.NCronJob/Registry/JobRegistry.cs
@@ -1,81 +1,21 @@
 using System.Collections.Immutable;
-using Microsoft.Extensions.Logging;
 
 namespace LinkDotNet.NCronJob;
 
-internal sealed partial class JobRegistry
+internal sealed class JobRegistry
 {
-    private readonly JobExecutor jobExecutor;
-    private readonly TimeProvider timeProvider;
-    private readonly ILogger<JobRegistry> logger;
     private readonly ImmutableArray<JobDefinition> cronJobs;
+    private readonly ImmutableArray<Type> allJobTypes;
 
-    public JobRegistry(
-        IEnumerable<JobDefinition> jobs,
-        JobExecutor jobExecutor,
-        TimeProvider timeProvider,
-        ILogger<JobRegistry> logger)
+    public JobRegistry(IEnumerable<JobDefinition> jobs)
     {
-        this.jobExecutor = jobExecutor;
-        this.timeProvider = timeProvider;
-        this.logger = logger;
-        cronJobs = [..jobs.Where(c => c.CronExpression is not null)];
+        var jobDefinitions = jobs as JobDefinition[] ?? jobs.ToArray();
+        allJobTypes = [..jobDefinitions.Select(j => j.Type)];
+        cronJobs = [.. jobDefinitions.Where(c => c.CronExpression is not null)];
     }
 
     public IReadOnlyCollection<JobDefinition> GetAllCronJobs() => cronJobs;
 
-    /// <inheritdoc />
-    public void RunInstantJob<TJob>(object? parameter = null, CancellationToken token = default)
-        where TJob : IJob => RunScheduledJob<TJob>(TimeSpan.Zero, parameter, token);
-
-    /// <inheritdoc />
-    public void RunScheduledJob<TJob>(TimeSpan delay, object? parameter = null, CancellationToken token = default)
-    {
-        token.Register(() => LogCancellationRequested(parameter));
-
-        var run = new JobDefinition(typeof(TJob), parameter, null, null);
-
-        _ = Task.Run<Task>(async () =>
-        {
-            var jobName = typeof(TJob).Name;
-
-            try
-            {
-                if (delay > TimeSpan.Zero)
-                {
-                    await TaskExtensions.LongDelaySafe(delay, timeProvider, token);
-                }
-
-                using (logger.BeginScope(new Dictionary<string, object>
-                       {
-                           { "JobName", jobName },
-                           { "JobTypeFullName", typeof(TJob).FullName ?? jobName }
-                       }))
-                {
-                    await jobExecutor.RunJob(run, CancellationToken.None);
-                }
-            }
-            catch
-            {
-                LogCancellationNotice(jobName);
-            }
-        }, token);
-    }
-
-    /// <inheritdoc />
-    public void RunScheduledJob<TJob>(DateTimeOffset startDate, object? parameter = null, CancellationToken token = default) where TJob : IJob
-    {
-        var utcNow = timeProvider.GetUtcNow();
-        ArgumentOutOfRangeException.ThrowIfLessThan(startDate, utcNow);
-
-        var delay = startDate - utcNow;
-        RunScheduledJob<TJob>(delay, parameter, token);
-    }
-
-    [LoggerMessage(LogLevel.Warning, "Job {JobName} cancelled by request.")]
-    private partial void LogCancellationNotice(string jobName);
-
-    [LoggerMessage(LogLevel.Debug, "Cancellation requested for CronRegistry {Parameter}.")]
-    private partial void LogCancellationRequested(object? parameter);
+    public bool IsJobRegistered<T>() => allJobTypes.Any(j => j == typeof(T));
 }
 


### PR DESCRIPTION
Instant jobs should directly throw if the underlying job is missing inside the container.